### PR TITLE
fixed missing child1-prefix in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ const childLogger = logger.getSubLogger({
 });
 childLogger.info("child1 message");
 // Output:
-// main-prefix parent-prefix MainLogger message
+// main-prefix parent-prefix child1-prefix MainLogger message
 
 const grandchildLogger = childLogger.getSubLogger({
   prefix: ["grandchild1-prefix"],


### PR DESCRIPTION
In the example for the prefixes the prefix 'child1-prefix' was missing.